### PR TITLE
Fixed license name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "name": "Matt Smith",
     "email": "mtscout6@gmail.com"
   },
-  "license": "Apache2",
+  "license": "Apache License, Version 2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/mtscout6/react-router-bootstrap.git"


### PR DESCRIPTION
I use [Bower Webjars](http://www.webjars.org/bower) which deploys Bower packages to Bintray for consumption by build tools such as maven or gradle.

The license name "Apache2" is not correctly parsed into a license name that Bintray understands and thus Bintray rejects its deployment. Therefore I changed the license name from "Apache2" to the canonical name "Apache License, Version 2.0".