### PR TITLE
Fixed license name again...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "name": "Matt Smith",
     "email": "mtscout6@gmail.com"
   },
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/react-bootstrap/react-router-bootstrap.git"


### PR DESCRIPTION
My previous PR #43 "Fixed license name in bower.json" was unfortunately wrong: bintray couldn't parse the license name "Apache License, Version 2.0".

I checked around for the "right spelling" and came up with this: "Apache-2.0"
Confident that bintray will be happy with that.

Sorry for the PR spamming!

/matthias