### PR TITLE
Add triggers with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ React.createClass({
 });
 ```
 
+It also defines modal and overlay triggers that forward router context:
+
+- `ModalTrigger` -> `RouterModalTrigger`
+- `OverlayTrigger` -> `RouterOverlayTrigger`
+
 ## Installation
 
 You will also (if you haven't already) want to install `react-router` and `react-bootstrap`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/react-bootstrap/react-router-bootstrap",
   "peerDependencies": {
-    "react-bootstrap": ">=0.15",
+    "react-bootstrap": ">=0.22",
     "react-router": ">=0.13.1"
   },
   "devDependencies": {

--- a/src/RouterModalTrigger.js
+++ b/src/RouterModalTrigger.js
@@ -1,0 +1,7 @@
+var React = require('react');
+
+var ModalTrigger = require('react-bootstrap/lib/ModalTrigger');
+
+module.exports = ModalTrigger.withContext({
+  router: React.PropTypes.func
+});

--- a/src/RouterOverlayTrigger.js
+++ b/src/RouterOverlayTrigger.js
@@ -1,0 +1,7 @@
+var React = require('react');
+
+var OverlayTrigger = require('react-bootstrap/lib/OverlayTrigger');
+
+module.exports = OverlayTrigger.withContext({
+  router: React.PropTypes.func
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 var ButtonLink = require('./ButtonLink');
+var ListGroupItemLink = require('./ListGroupItemLink');
 var MenuItemLink = require('./MenuItemLink');
 var NavItemLink = require('./NavItemLink');
-var ListGroupItemLink = require('./ListGroupItemLink');
+var RouterModalTrigger = require('./RouterModalTrigger');
+var RouterOverlayTrigger = require('./RouterOverlayTrigger');
 
 module.exports = {
   ButtonLink: ButtonLink,
+  ListGroupItemLink: ListGroupItemLink,
   MenuItemLink: MenuItemLink,
   NavItemLink: NavItemLink,
-  ListGroupItemLink: ListGroupItemLink
+  RouterModalTrigger: RouterModalTrigger,
+  RouterOverlayTrigger: RouterOverlayTrigger
 };

--- a/tests/RouterModalTrigger.spec.js
+++ b/tests/RouterModalTrigger.spec.js
@@ -1,0 +1,13 @@
+/* globals describe, it, expect */
+
+var React = require('react');
+
+var RouterModalTrigger = require('../src/RouterModalTrigger');
+
+describe('A RouterModalTrigger', function() {
+  it('has the right contextTypes', function() {
+    expect(RouterModalTrigger.contextTypes).to.eql({
+      router: React.PropTypes.func
+    });
+  });
+});

--- a/tests/RouterOverlayTrigger.spec.js
+++ b/tests/RouterOverlayTrigger.spec.js
@@ -1,0 +1,13 @@
+/* globals describe, it, expect */
+
+var React = require('react');
+
+var RouterOverlayTrigger = require('../src/RouterOverlayTrigger');
+
+describe('A RouterOverlayTrigger', function() {
+  it('has the right contextTypes', function() {
+    expect(RouterOverlayTrigger.contextTypes).to.eql({
+      router: React.PropTypes.func
+    });
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,8 @@ global.assert = chai.assert;
 global.TestUtils = require('react/addons').addons.TestUtils;
 
 require('./ButtonLink.spec.js');
+require('./ListGroupItemLink.spec.js');
 require('./MenuItemLink.spec.js');
 require('./NavItemLink.spec.js');
-require('./ListGroupItemLink.spec.js');
+require('./RouterModalTrigger.spec.js');
+require('./RouterOverlayTrigger.spec.js');


### PR DESCRIPTION
For react-bootstrap/react-router-bootstrap#50

Tests won't pass until v0.22.0 of react-bootstrap is actually released (I ran against `master` of react-bootstrap locally).

Also alphabetized some lists of components.