### PR TITLE
[fixed] Don't follow href on disabled links

### DIFF
--- a/src/LinkMixin.js
+++ b/src/LinkMixin.js
@@ -59,6 +59,7 @@ module.exports = {
     var clickResult;
     
     if (this.props.disabled) {
+      event.preventDefault();
       return;
     }
 


### PR DESCRIPTION
I tried a bunch of things to extend the test case to cover this, but none of them worked.

`TestLocation` doesn't actually capture anything to do with `href`, and replacing it with `HashLocation` didn't seem to work for me either.