### PR TITLE
React bootstrap bower dependency to use concatenated bundle only

### DIFF
--- a/tests/bower-imports-module.spec.js
+++ b/tests/bower-imports-module.spec.js
@@ -1,0 +1,21 @@
+import loader from '../webpack/bower-imports-loader';
+
+describe('bower-imports-loader', function() {
+  it('replaces react-bootstrap/lib/* imports to work with bower dependency', function() {
+    const input = `import React from 'react';
+
+import Button from 'react-bootstrap/lib/Button';
+import LinkMixin from './LinkMixin';
+
+const ButtonLink = React.createClass({`;
+
+    const expected = `import React from 'react';
+
+import {Button} from 'react-bootstrap';
+import LinkMixin from './LinkMixin';
+
+const ButtonLink = React.createClass({`;
+
+    loader(input).should.equal(expected);
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,3 +15,4 @@ import './MenuItemLink.spec.js';
 import './NavItemLink.spec.js';
 import './RouterModalTrigger.spec.js';
 import './RouterOverlayTrigger.spec.js';
+import './bower-imports-module.spec.js';

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import webpack from 'webpack';
 
 let plugins = [];
@@ -12,7 +13,7 @@ if (process.env.COMPRESS) {
   );
 }
 
-module.exports = {
+export default {
   entry: {
     'ReactRouterBootstrap': './src/index.js'
   },
@@ -26,7 +27,13 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js/, loader: 'babel', exclude: /node_modules/ }
+      {
+        test: /\.js/,
+        loaders: [
+          'babel',
+          path.join(__dirname, 'webpack/bower-imports-loader.js')
+        ],
+        exclude: /node_modules/ }
     ]
   },
 
@@ -55,54 +62,6 @@ module.exports = {
         commonjs2: 'react-bootstrap',
         commonjs: 'react-bootstrap',
         amd: 'react-bootstrap'
-      }
-    },
-    {
-      'react-bootstrap/lib/Button': {
-        root: ['ReactBootstrap', 'Button'],
-        commonjs2: 'react-bootstrap/lib/Button',
-        commonjs: 'react-bootstrap/lib/Button',
-        amd: 'react-bootstrap/lib/Button'
-      }
-    },
-    {
-      'react-bootstrap/lib/NavItem': {
-        root: ['ReactBootstrap', 'NavItem'],
-        commonjs2: 'react-bootstrap/lib/NavItem',
-        commonjs: 'react-bootstrap/lib/NavItem',
-        amd: 'react-bootstrap/lib/NavItem'
-      }
-    },
-    {
-      'react-bootstrap/lib/MenuItem': {
-        root: ['ReactBootstrap', 'MenuItem'],
-        commonjs2: 'react-bootstrap/lib/MenuItem',
-        commonjs: 'react-bootstrap/lib/MenuItem',
-        amd: 'react-bootstrap/lib/MenuItem'
-      }
-    },
-    {
-      'react-bootstrap/lib/ListGroupItem': {
-        root: ['ReactBootstrap', 'ListGroupItem'],
-        commonjs2: 'react-bootstrap/lib/ListGroupItem',
-        commonjs: 'react-bootstrap/lib/ListGroupItem',
-        amd: 'react-bootstrap/lib/ListGroupItem'
-      }
-    },
-    {
-      'react-bootstrap/lib/ModalTrigger': {
-        root: ['ReactBootstrap', 'ModalTrigger'],
-        commonjs2: 'react-bootstrap/lib/ModalTrigger',
-        commonjs: 'react-bootstrap/lib/ModalTrigger',
-        amd: 'react-bootstrap/lib/ModalTrigger'
-      }
-    },
-    {
-      'react-bootstrap/lib/OverlayTrigger': {
-        root: ['ReactBootstrap', 'OverlayTrigger'],
-        commonjs2: 'react-bootstrap/lib/OverlayTrigger',
-        commonjs: 'react-bootstrap/lib/OverlayTrigger',
-        amd: 'react-bootstrap/lib/OverlayTrigger'
       }
     }
   ],

--- a/webpack/bower-imports-loader.js
+++ b/webpack/bower-imports-loader.js
@@ -1,0 +1,7 @@
+export default function bowerImportsLoader(source) {
+  const rgx = /^import (.*) from 'react-bootstrap\/lib\/.*';/;
+
+  return source.split('\n')
+    .map(line => line.replace(rgx, "import {$1} from 'react-bootstrap';"))
+    .join('\n');
+}


### PR DESCRIPTION
Depends on PR #73, which is why you see two commits at the moment.

Configures webpack build to change react-bootstrap/lib/* imports to react-bootstrap

This will enable react-bootstrap/react-bootstrap#693 without breaking this library. It changes the concatenated and minified builds to require the entire react-bootstrap library as a dependency instead of the piecemeal approach. The npm distribution of individual files is not affected.