### PR TITLE
Remove 'classnames' dependency as a result of refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,6 @@ Router.run(routes, function (Handler) {
 
 ```
 
-## Browser support
-
-This package depends on classnames, which requires [a polyfill for non-ES5 capable browsers](https://github.com/JedWatson/classnames#polyfills-needed-to-support-older-browsers).
-
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -66,8 +66,5 @@
   },
   "files": [
     "lib"
-  ],
-  "dependencies": {
-    "classnames": "^2.0.0"
-  }
+  ]
 }

--- a/src/ButtonLink.js
+++ b/src/ButtonLink.js
@@ -7,30 +7,11 @@ const ButtonLink = React.createClass({
   mixins: [
     LinkMixin
   ],
-  contextTypes: {
-    router: React.PropTypes.func.isRequired
-  },
 
   render() {
-    let {
-      to,
-      params,
-      query,
-      active,
-      ...props
-    } = this.props;
-
-    if (this.props.active === undefined) {
-      active = this.context.router.isActive(to, params, query);
-    }
-
     return (
-      <Button {...props}
-        href={this.getHref()}
-        active={active}
-        onClick={this.handleRouteTo}
-        ref='button'>
-          {this.props.children}
+      <Button {...this.getLinkProps()} ref='button'>
+        {this.props.children}
       </Button>
     );
   }

--- a/src/LinkMixin.js
+++ b/src/LinkMixin.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 
 function isLeftClickEvent(event) {
   return event.button === 0;
@@ -11,6 +10,7 @@ function isModifiedEvent(event) {
 
 export default {
   propTypes: {
+    active: React.PropTypes.bool,
     activeClassName: React.PropTypes.string.isRequired,
     disabled: React.PropTypes.bool,
     to: React.PropTypes.string.isRequired,
@@ -22,7 +22,6 @@ export default {
     router: React.PropTypes.func.isRequired
   },
 
-
   getDefaultProps() {
     return {
       activeClassName: 'active'
@@ -30,28 +29,28 @@ export default {
   },
 
   /**
-   * Returns the value of the "href" attribute to use on the DOM element.
+   * Returns props except those used by this Mixin
+   * Gets "active" from router if needed.
+   * Gets the value of the "href" attribute to use on the DOM element.
+   * Sets "onClick" to "handleRouteTo".
    */
-  getHref() {
-    return this.context.router.makeHref(this.props.to, this.props.params, this.props.query);
-  },
+  getLinkProps() {
+    let {
+      to,
+      params,
+      query,
+      ...props // eslint-disable-line object-shorthand
+    } = this.props;
 
-  /**
-   * Returns the value of the "class" attribute to use on the DOM element, which contains
-   * the value of the activeClassName property when this <Link> is active.
-   */
-  getClassName() {
-    let classSet = {};
-
-    if (this.props.className) {
-      classSet[this.props.className] = true;
+    if (this.props.active === undefined) {
+      props.active = this.context.router.isActive(to, params, query);
     }
 
-    if (this.context.router.isActive(this.props.to, this.props.params, this.props.query)) {
-      classNames[this.props.activeClassName] = true;
-    }
+    props.href = this.context.router.makeHref(to, params, query);
 
-    return classNames(classSet);
+    props.onClick = this.handleRouteTo;
+
+    return props;
   },
 
   handleRouteTo(event) {

--- a/src/ListGroupItemLink.js
+++ b/src/ListGroupItemLink.js
@@ -7,29 +7,10 @@ const LinkGroupItemLink = React.createClass({
   mixins: [
     LinkMixin
   ],
-  contextTypes: {
-    router: React.PropTypes.func.isRequired
-  },
 
   render() {
-    let {
-      to,
-      params,
-      query,
-      active,
-      ...props
-    } = this.props;
-
-    if (this.props.active === undefined) {
-      active = this.context.router.isActive(to, params, query);
-    }
-
     return (
-      <ListGroupItem {...props}
-        href={this.getHref()}
-        active={active}
-        onClick={this.handleRouteTo}
-        ref='listGroupItem'>
+      <ListGroupItem {...this.getLinkProps()} ref='listGroupItem'>
         {this.props.children}
       </ListGroupItem>
     );

--- a/src/MenuItemLink.js
+++ b/src/MenuItemLink.js
@@ -7,32 +7,13 @@ const MenuItemLink = React.createClass({
   mixins: [
     LinkMixin
   ],
-  contextTypes: {
-    router: React.PropTypes.func.isRequired
-  },
 
   render() {
-    let {
-      to,
-      params,
-      query,
-      active,
-      onSelect, // eslint-disable-line no-unused-vars
-      ...props
-    } = this.props;
-
-    if (active === undefined) {
-      active = this.context.router.isActive(to, params, query);
-    }
+    let props = this.getLinkProps();
+    delete props.onSelect; // this is done on the copy of this.props
 
     return (
-      <MenuItem
-        {...props}
-        href={this.getHref()}
-        active={active}
-        onClick={this.handleRouteTo}
-        ref="menuItem"
-      >
+      <MenuItem {...props} ref="menuItem">
         {this.props.children}
       </MenuItem>
     );

--- a/src/NavItemLink.js
+++ b/src/NavItemLink.js
@@ -7,29 +7,10 @@ const NavItemLink = React.createClass({
   mixins: [
     LinkMixin
   ],
-  contextTypes: {
-    router: React.PropTypes.func.isRequired
-  },
 
-  render: function() {
-    let {
-      to,
-      params,
-      query,
-      active,
-      ...props
-    } = this.props;
-
-    if (this.props.active === undefined) {
-      active = this.context.router.isActive(to, params, query);
-    }
-
+  render() {
     return (
-      <NavItem {...props}
-        href={this.getHref()}
-        active={active}
-        onClick={this.handleRouteTo}
-        ref="navItem">
+      <NavItem {...this.getLinkProps()} ref="navItem">
         {this.props.children}
       </NavItem>
     );

--- a/tests/ButtonLink.spec.js
+++ b/tests/ButtonLink.spec.js
@@ -100,12 +100,12 @@ describe('A ButtonLink', function () {
   describe('when clicked', function () {
     it('calls a user defined click handler', function (done) {
       let ButtonLinkHandler = React.createClass({
-        handleClick: function (event) {
+        handleClick(event) {
           assert.ok(true);
           done();
         },
 
-        render: function () {
+        render() {
           return <ButtonLink to="foo" onClick={this.handleClick}>ButtonLink</ButtonLink>;
         }
       });
@@ -131,11 +131,11 @@ describe('A ButtonLink', function () {
       testLocation.history = ['/link'];
 
       let ButtonLinkHandler = React.createClass({
-        handleClick: function () {
+        handleClick() {
           // just here to make sure click handlers don't prevent it from happening
         },
 
-        render: function () {
+        render() {
           return <ButtonLink to="foo" onClick={this.handleClick}>ButtonLink</ButtonLink>;
         }
       });


### PR DESCRIPTION
Address eslint warnings.

DRY refactor the code. Move all general logic into mixin.
As a sidenote: the main logic of this project is in the `LinkMixin` mixin now.

`LinkMixin` is not a public API in `src/index.js`
therefore `getClassName()` method is not public too
and because it is used nowhere it has been removed.

And as a consequence `classnames` dependency has been removed also.

Closes #75