### PR TITLE
License should be a valid SPDX license expression.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "name": "Matt Smith",
     "email": "mtscout6@gmail.com"
   },
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/react-bootstrap/react-router-bootstrap/issues"
   },


### PR DESCRIPTION
fixes:
```
package.json react-router-bootstrap@0.16.0 license should be a valid SPDX license expression
```
npm error