### PR TITLE
Add router to contextTypes of LinkContainer.

### DIFF
--- a/src/LinkContainer.js
+++ b/src/LinkContainer.js
@@ -59,7 +59,8 @@ LinkContainer.propTypes = {
 };
 
 LinkContainer.contextTypes = {
-  history: React.PropTypes.object
+  history: React.PropTypes.object,
+  router: React.PropTypes.object
 };
 
 LinkContainer.defaultProps = {


### PR DESCRIPTION
`react-router` v2.x will add only `router` to context: https://github.com/rackt/react-router/blob/master/upgrade-guides/v2.0.0.md#changes-to-thiscontext

Currently, if a user updates his project to use `react-router` v2.x (I tried with v2.0.0-rc2) it will break his app because `LinkContainer`'s `contextTypes` include only `history`.

This PR adds `router` to  `contextTypes` of `LinkContainer` and therefore allows users to use it with `react-router` v2.x 