### PR TITLE
Respect explicit active prop on container

### DIFF
--- a/src/LinkContainer.js
+++ b/src/LinkContainer.js
@@ -32,7 +32,10 @@ export default class LinkContainer extends React.Component {
     // Ignore if rendered outside Router context; simplifies unit testing.
     if (router) {
       props.href = router.createHref(to);
-      props.active = router.isActive(to, onlyActiveOnIndex);
+
+      if (props.active == null) {
+        props.active = router.isActive(to, onlyActiveOnIndex);
+      }
     }
 
     return React.cloneElement(React.Children.only(children), props);
@@ -46,6 +49,7 @@ LinkContainer.propTypes = {
     React.PropTypes.object,
   ]).isRequired,
   onClick: React.PropTypes.func,
+  active: React.PropTypes.bool,
   disabled: React.PropTypes.bool.isRequired,
   children: React.PropTypes.node.isRequired
 };

--- a/tests/LinkContainer.spec.js
+++ b/tests/LinkContainer.spec.js
@@ -165,6 +165,30 @@ describe('LinkContainer', () => {
         it('should not be active when on a different route', () => {
           expect(renderComponent('/bar').className).to.not.match(/\bactive\b/);
         });
+
+        it('should respect explicit active prop on container', () => {
+          const router = ReactTestUtils.renderIntoDocument(
+            <Router history={createMemoryHistory('/foo')}>
+              <Route
+                path="/"
+                component={() => (
+                  <LinkContainer to="/bar" active>
+                    <Component>Bar</Component>
+                  </LinkContainer>
+                )}
+              >
+                <Route path="foo" />
+                <Route path="bar" />
+              </Route>
+            </Router>
+          );
+
+          const component = ReactTestUtils.findRenderedComponentWithType(
+            router, Component
+          );
+          expect(ReactDOM.findDOMNode(component).className)
+            .to.match(/\bactive\b/);
+        });
       });
 
       describe('disabled state', () => {


### PR DESCRIPTION
Closes https://github.com/react-bootstrap/react-router-bootstrap/issues/134

We actually can't check `child.props.active` because sometimes this defaults to `false` for some R-B components.