### PR TITLE
Fix webpack config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -32,11 +32,11 @@ export default {
       },
     },
     {
-      'react-router': {
-        root: 'ReactRouter',
-        commonjs2: 'react-router',
-        commonjs: 'react-router',
-        amd: 'react-router',
+      'react-router-dom': {
+        root: 'ReactRouterDOM',
+        commonjs2: 'react-router-dom',
+        commonjs: 'react-router-dom',
+        amd: 'react-router-dom',
       },
     },
   ],


### PR DESCRIPTION
In #201, the switch to `react-router-dom` was made but the webpack config was not updated. Therefore, the current UMD bundles include `react-router-dom` and depend on `react-router`.