### PR TITLE
Use Public API for React-Router instead of Private Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 amd
 lib
 tmp-bower-repo
+.idea
+package-lock.json

--- a/src/IndexLinkContainer.js
+++ b/src/IndexLinkContainer.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
 
 import LinkContainer from './LinkContainer';
 
 // Don't use a stateless function, to allow users to set a ref.
 /* eslint-disable react/prefer-stateless-function */
-export default class IndexLinkContainer extends React.Component {
+export class IndexLinkContainer extends React.Component {
   render() {
     return (
       <LinkContainer {...this.props} exact />
@@ -12,3 +13,5 @@ export default class IndexLinkContainer extends React.Component {
   }
 }
 /* eslint-enable react/prefer-stateless-function */
+
+export default withRouter(IndexLinkContainer);

--- a/src/LinkContainer.js
+++ b/src/LinkContainer.js
@@ -11,7 +11,10 @@ export class LinkContainer extends Component {
       push: PropTypes.func.isRequired,
       replace: PropTypes.func.isRequired,
       createHref: PropTypes.func.isRequired,
-    }),
+    }).isRequired,
+    location: PropTypes.object,
+    match: PropTypes.object,
+    staticContext: PropTypes.object,
     children: PropTypes.element.isRequired,
     onClick: PropTypes.func,
     replace: PropTypes.bool,
@@ -66,8 +69,11 @@ export class LinkContainer extends Component {
   render() {
     const {
       history,
+      location: _location,            // eslint-disable-line no-unused-vars
+      match: _match,                  // eslint-disable-line no-unused-vars
+      staticContext: _staticContext,  // eslint-disable-line no-unused-vars
       children,
-      replace, // eslint-disable-line no-unused-vars
+      replace,                          // eslint-disable-line no-unused-vars
       to,
       exact,
       strict,

--- a/src/LinkContainer.js
+++ b/src/LinkContainer.js
@@ -1,22 +1,17 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Route } from 'react-router-dom';
+import { Route, withRouter } from 'react-router-dom';
 
 const isModifiedEvent = (event) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 
-export default class LinkContainer extends Component {
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired,
-        replace: PropTypes.func.isRequired,
-        createHref: PropTypes.func.isRequired,
-      }).isRequired,
-    }).isRequired,
-  };
-
+export class LinkContainer extends Component {
   static propTypes = {
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+      replace: PropTypes.func.isRequired,
+      createHref: PropTypes.func.isRequired,
+    }),
     children: PropTypes.element.isRequired,
     onClick: PropTypes.func,
     replace: PropTypes.bool,
@@ -58,8 +53,7 @@ export default class LinkContainer extends Component {
     ) {
       event.preventDefault();
 
-      const { history } = this.context.router;
-      const { replace, to } = this.props;
+      const { replace, to, history } = this.props;
 
       if (replace) {
         history.replace(to);
@@ -67,10 +61,11 @@ export default class LinkContainer extends Component {
         history.push(to);
       }
     }
-  }
+  };
 
   render() {
     const {
+      history,
       children,
       replace, // eslint-disable-line no-unused-vars
       to,
@@ -84,7 +79,7 @@ export default class LinkContainer extends Component {
       ...props,
     } = this.props;
 
-    const href = this.context.router.history.createHref(
+    const href = history.createHref(
       typeof to === 'string' ? { pathname: to } : to
     );
 
@@ -114,3 +109,5 @@ export default class LinkContainer extends Component {
     );
   }
 }
+
+export default withRouter(LinkContainer);

--- a/test/LinkContainer.spec.js
+++ b/test/LinkContainer.spec.js
@@ -4,7 +4,7 @@ import * as ReactBootstrap from 'react-bootstrap';
 import { findDOMNode } from 'react-dom';
 import { Route, MemoryRouter as Router } from 'react-router-dom';
 
-import LinkContainer from '../src/LinkContainer';
+import LinkContainer, { LinkContainer as RawLinkContainer } from '../src/LinkContainer';
 
 describe('LinkContainer', () => {
   [
@@ -62,7 +62,7 @@ describe('LinkContainer', () => {
         );
 
         const container = ReactTestUtils.findRenderedComponentWithType(
-          router, LinkContainer
+          router, RawLinkContainer
         );
         const component = ReactTestUtils.findRenderedComponentWithType(
           router, Component


### PR DESCRIPTION
Per: https://github.com/ReactTraining/react-router/releases/tag/v4.4.0-beta.0

> We also made it explicit in this release that you can't use contextTypes to access properties on this.context.router anymore. If you try, you'll get a warning. That's our private API! If you need stuff on context, just use a <Route> or withRouter instead. It's all the same stuff, and that's our public API 👍
> 
> 🚨 In a future release, we will remove the old context API entirely so your app will break if you were using our private API. 🚨

Since react-router-bootstrap uses the forbidden contextTypes, this PR addresses that.

In short, LinkContainer is now exported by default, wrapped by `withRouter`. This exposes `history` and such directly as a property on LinkContainer.

Additionally, the original unwrapped LinkContainer class is exported, if desired.

## Summary of changes:
* IndexLinkContainer:
   * Wrapped `withRouter` as default export,
   * Now exports original component separately
* LinkContainer:
   * Wrapped `withRouter` as default export,
   * Now exports original component separately
   * `contextTypes` validation has been removed
   * `propTypes` now expects `history` object (required), as it is expected to be wrapped `withRouter`
   * Added propTypes: `location`, `match`, `staticContext`, since `withRouter` will provide them
   * `this.context.router.history` references replaced with `this.props.history`
   * Updated `render()` to strip props (`location`, `match`, `staticContext`) from children
* Tests updated to deal with wrapped component vs real component references
* git ignore updates

Fixes #237