### PR TITLE
Remove lodash dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "html-webpack-plugin": "^5.5.0",
     "jasmine-enzyme": "^7.1.2",
     "jest": "^26.6.3",
-    "lodash": "^4.17.21",
     "prettier": "^2.4.1",
     "react": "^16.14.0",
     "react-bootstrap": "^1.6.4",

--- a/src/LinkContainer.js
+++ b/src/LinkContainer.js
@@ -6,7 +6,6 @@ import {
   useMatch,
   useNavigate,
 } from 'react-router-dom';
-import { isFunction } from 'lodash';
 
 const isModifiedEvent = (event) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
@@ -32,7 +31,7 @@ const LinkContainer = ({
   const child = React.Children.only(children);
 
   const isActive = !!(getIsActive
-    ? isFunction(getIsActive)
+    ? typeof getIsActive === 'function'
       ? getIsActive(match, location)
       : getIsActive
     : match);


### PR DESCRIPTION
resolve #276 since isFunction is the only method used in lodash in their entire project, I think it's safe to remove it from the package.json and replace it with the generic function check