### PR TITLE
Update LinkContainer props to follow more closely to v6 standards

### DIFF
--- a/src/LinkContainer.js
+++ b/src/LinkContainer.js
@@ -11,21 +11,19 @@ const isModifiedEvent = (event) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 
 const LinkContainer = ({
-  children,
-  onClick,
-  replace, // eslint-disable-line no-unused-vars
-  to,
-  activeClassName,
-  className,
-  activeStyle,
-  style,
-  isActive: getIsActive,
-  // eslint-disable-next-line comma-dangle
-  ...props
-}) => {
+                         children,
+                         onClick,
+                         replace, // eslint-disable-line no-unused-vars
+                         to,
+                         className,
+                         style,
+                         isActive: getIsActive,
+                         // eslint-disable-next-line comma-dangle
+                         ...props
+                       }) => {
   const path = typeof to === 'object' ? to.pathname : to;
   const navigate = useNavigate();
-  const href = useHref(typeof to === 'string' ? { pathname: to } : to);
+  const href = useHref(typeof to === 'string' ? {pathname: to} : to);
   const match = useMatch(path);
   const location = useLocation();
   const child = React.Children.only(children);
@@ -61,13 +59,12 @@ const LinkContainer = ({
   return React.cloneElement(child, {
     ...props,
     className: [
-      className,
+      typeof className === 'function' ? className({isActive}) : className,
       child.props.className,
-      isActive ? activeClassName : null,
     ]
       .join(' ')
       .trim(),
-    style: isActive ? { ...style, ...activeStyle } : style,
+    style: typeof style === 'function' ? style({isActive}) : style,
     href,
     onClick: handleClick,
   });
@@ -78,24 +75,18 @@ LinkContainer.propTypes = {
   onClick: PropTypes.func,
   replace: PropTypes.bool,
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-  className: PropTypes.string,
-  activeClassName: PropTypes.string,
-  style: PropTypes.objectOf(
+  className: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  style: PropTypes.oneOfType([PropTypes.objectOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  ),
-  activeStyle: PropTypes.objectOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  ),
+  ), PropTypes.func]),
   isActive: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 };
 
 LinkContainer.defaultProps = {
   replace: false,
-  activeClassName: 'active',
   onClick: null,
-  className: null,
+  className: ({isActive}) => isActive ? 'active' : null,
   style: null,
-  activeStyle: null,
   isActive: null,
 };
 


### PR DESCRIPTION
removes `activeClassName` and `activeStyle` props and instead uses the new v6 standard by passing `isActive` to `className` and `style` (when they are functions).

https://reactrouter.com/docs/en/v6/components/nav-link